### PR TITLE
fix: 修复旧料状态更新为正常

### DIFF
--- a/logic/order/sales_create.go
+++ b/logic/order/sales_create.go
@@ -247,7 +247,7 @@ func (l *OrderSalesCreateLogic) loopOld(p *types.OrderSalesCreateReqProductOld, 
 
 	// 更新商品状态
 	if err := l.Tx.Model(&old).Updates(model.ProductOld{
-		Status: enums.ProductStatusSold,
+		Status: enums.ProductStatusNormal,
 	}).Error; err != nil {
 		return errors.New("旧料状态更新失败")
 	}


### PR DESCRIPTION
fix #51

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **修复**
  - 修正了在创建销售订单时旧产品的状态更新逻辑，旧产品的状态将被设置为“正常”而非“已售”。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->