### PR TITLE
fix(productAllocate): 修复调拨ID使用错误

### DIFF
--- a/logic/product/allocate.go
+++ b/logic/product/allocate.go
@@ -202,7 +202,7 @@ func (p *ProductAllocateLogic) Add(req *types.ProductAllocateAddReq) *errors.Err
 			// 添加产品
 			for _, p := range product {
 				if err := tx.Table("product_allocate_finished_products").Create(map[string]any{
-					"product_allocate_id": data.Id,
+					"product_allocate_id": allocate.Id,
 					"product_finished_id": p.Id,
 				}).Error; err != nil {
 					return err
@@ -228,7 +228,7 @@ func (p *ProductAllocateLogic) Add(req *types.ProductAllocateAddReq) *errors.Err
 			// 添加产品
 			for _, p := range product {
 				if err := tx.Table("product_allocate_old_products").Create(map[string]any{
-					"product_allocate_id": data.Id,
+					"product_allocate_id": allocate.Id,
 					"product_old_id":      p.Id,
 				}).Error; err != nil {
 					return err

--- a/router/api.go
+++ b/router/api.go
@@ -357,7 +357,7 @@ func Api(g *gin.Engine) {
 				}
 			}
 
-			// 成品调拨
+			// 货品调拨
 			allocate := products.Group("/allocate")
 			{
 				allocate.GET("/where", product.ProductAllocateController{}.Where) // 调拨单筛选


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 修正了产品调拨时产品分配ID的引用错误，确保添加成品和旧品时正确关联到现有的产品调拨记录。

* **Documentation**
  * 更新了接口路由注释，将“成品调拨”更正为“货品调拨”。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->