### PR TITLE
feat(region): 添加默认区域到区域列表

### DIFF
--- a/logic/region/region.go
+++ b/logic/region/region.go
@@ -67,6 +67,13 @@ func (l *RegionLogic) My(req *types.RegionListMyReq) (*[]model.Region, error) {
 		return nil, errors.New("获取区域列表失败")
 	}
 
+	if len(regions) >= 2 {
+		def := model.Region{}.Default(l.Staff.Identity)
+		if def != nil {
+			regions = append([]model.Region{*def}, regions...)
+		}
+	}
+
 	return &regions, nil
 }
 

--- a/model/region.go
+++ b/model/region.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"fmt"
+	"jdy/enums"
 	"jdy/types"
 
 	"gorm.io/gorm"
@@ -33,6 +34,17 @@ func (Region) Preloads(db *gorm.DB) *gorm.DB {
 	db = db.Preload("Superiors")
 
 	return db
+}
+
+func (Region) Default(identity enums.Identity) *Region {
+	if identity < enums.IdentityAdmin {
+		return nil
+	}
+	def := &Region{
+		Name: "全部",
+	}
+
+	return def
 }
 
 func init() {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 当用户拥有两个及以上区域时，区域列表将自动在最前面添加一个默认区域“全部”，提升区域选择的灵活性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->