### PR TITLE
refactor(region): 优化区域列表默认值逻辑

### DIFF
--- a/logic/region/region.go
+++ b/logic/region/region.go
@@ -67,11 +67,9 @@ func (l *RegionLogic) My(req *types.RegionListMyReq) (*[]model.Region, error) {
 		return nil, errors.New("获取区域列表失败")
 	}
 
-	if len(regions) >= 2 {
-		def := model.Region{}.Default(l.Staff.Identity)
-		if def != nil {
-			regions = append([]model.Region{*def}, regions...)
-		}
+	def := model.Region{}.Default(l.Staff.Identity)
+	if def != nil {
+		regions = append([]model.Region{*def}, regions...)
 	}
 
 	return &regions, nil


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **修复**
  * 默认区域现在始终会添加到区域列表的开头，无论当前区域数量多少。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->