### PR TITLE
refactor: 重构随机码生成逻辑，限制字母数量且数字开头

### DIFF
--- a/logic/order/sales_create.go
+++ b/logic/order/sales_create.go
@@ -423,7 +423,7 @@ func (l *OrderSalesCreateLogic) getProductFinished(product_id string) (*model.Pr
 
 func (l *OrderSalesCreateLogic) getProductOld(product_id string, p *types.OrderSalesCreateReqProductOld) (*model.ProductOld, error) {
 	old := model.ProductOld{
-		Code:                    strings.ToUpper("JL" + utils.RandomAlphanumericUpper(8)),
+		Code:                    strings.ToUpper("JL" + utils.RandomCode(8)),
 		CodeFinished:            strings.ToUpper(p.Code),
 		Name:                    p.Name,
 		LabelPrice:              p.LabelPrice,

--- a/logic/product/finished_damage.go
+++ b/logic/product/finished_damage.go
@@ -169,7 +169,7 @@ func (l *ProductFinishedDamageLogic) Conversion(req *types.ProductConversionReq)
 			}
 
 			data := model.ProductOld{
-				Code:            strings.ToUpper("JL" + utils.RandomAlphanumericUpper(8)),
+				Code:            strings.ToUpper("JL" + utils.RandomCode(8)),
 				CodeFinished:    strings.ToUpper(product.Code),
 				Name:            product.Name,
 				Status:          enums.ProductStatusNormal,

--- a/utils/string.go
+++ b/utils/string.go
@@ -8,9 +8,9 @@ import (
 )
 
 const (
-	digits       = "0123456789"                 // 数字
-	letter       = "abcdefghijklmnopqrstuvwxyz" // 小写字母
-	letter_upper = "ABCDEFGHIJKLMNOPQRSTUVWXYZ" // 大写字母
+	digits       = "0123456789"              // 数字
+	letter       = "abcdefghjkmnpqrstuvwxyz" // 小写字母（去除i、l、o）
+	letter_upper = "ABCDEFGHJKMNPQRSTUVWXYZ" // 大写字母（去除I、L、O）
 )
 
 // 随机字符串（字母数字）

--- a/utils/string.go
+++ b/utils/string.go
@@ -8,27 +8,64 @@ import (
 )
 
 const (
-	letterBytes      = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-	letterBytesUpper = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	digits       = "0123456789"                 // 数字
+	letter       = "abcdefghijklmnopqrstuvwxyz" // 小写字母
+	letter_upper = "ABCDEFGHIJKLMNOPQRSTUVWXYZ" // 大写字母
 )
 
 // 随机字符串（字母数字）
 func RandomAlphanumeric(length int) string {
+	if length <= 0 {
+		return ""
+	}
+
 	rand.Seed(uint64(time.Now().UnixNano()))
+	// 小写字母+数字
+	bytes := digits + letter
 	b := make([]byte, length)
 	for i := range b {
-		b[i] = letterBytes[rand.Intn(len(letterBytes))]
+		b[i] = bytes[rand.Intn(len(bytes))]
 	}
 	return string(b)
 }
 
-// 随机字符串（字母数字大写）
-func RandomAlphanumericUpper(length int) string {
-	rand.Seed(uint64(time.Now().UnixNano()))
-	b := make([]byte, length)
-	for i := range b {
-		b[i] = letterBytesUpper[rand.Intn(len(letterBytesUpper))]
+// 随机条码【数字+字母（字母最多 2 位且不能字母开头）】
+func RandomCode(length int) string {
+	if length <= 0 {
+		return ""
 	}
+
+	rand.Seed(uint64(time.Now().UnixNano()))
+
+	b := make([]byte, length)
+
+	// 确保第一个字符是数字
+	b[0] = digits[rand.Intn(len(digits))]
+
+	// 计算允许的最大字母数量（不超过2且不超过剩余位置数）
+	maxLetters := 2
+	remaining := length - 1
+	if remaining < maxLetters {
+		maxLetters = remaining
+	}
+	letterCount := rand.Intn(maxLetters + 1) // 随机生成0~maxLetters的字母数量
+
+	// 随机选择字母出现的位置（在非首字符的位置）
+	if letterCount > 0 {
+		positions := rand.Perm(remaining)[:letterCount] // 生成不重复的随机位置
+		for _, pos := range positions {
+			// 注意：positions是相对于b[1:]的索引，实际位置需+1
+			b[pos+1] = letter_upper[rand.Intn(len(letter))]
+		}
+	}
+
+	// 填充剩余位置为数字
+	for i := 1; i < length; i++ {
+		if b[i] == 0 { // 未设置的位置填充数字
+			b[i] = digits[rand.Intn(len(digits))]
+		}
+	}
+
 	return string(b)
 }
 

--- a/utils/string.go
+++ b/utils/string.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	digits       = "0123456789"              // 数字
+	digits       = "23456789"                // 数字（去除0、1）
 	letter       = "abcdefghjkmnpqrstuvwxyz" // 小写字母（去除i、l、o）
 	letter_upper = "ABCDEFGHJKMNPQRSTUVWXYZ" // 大写字母（去除I、L、O）
 )

--- a/utils/string.go
+++ b/utils/string.go
@@ -55,7 +55,7 @@ func RandomCode(length int) string {
 		positions := rand.Perm(remaining)[:letterCount] // 生成不重复的随机位置
 		for _, pos := range positions {
 			// 注意：positions是相对于b[1:]的索引，实际位置需+1
-			b[pos+1] = letter_upper[rand.Intn(len(letter))]
+			b[pos+1] = letter_upper[rand.Intn(len(letter_upper))]
 		}
 	}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新功能
  - 旧品编码生成规则更新：旧品编码仍以“JL”前缀保留，生成规则改为以数字开头，后续位最多包含两位大写字母，其余为数字，已应用于旧品创建与成品报损转换场景。
- 重构
  - 统一并替换随机码生成逻辑，缩小候选字符集并新增对空长度输入的处理，提升编码可控性与一致性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->