### PR TITLE
fix(statistic): 限制销售详情日报参数验证和权限控制

### DIFF
--- a/controller/statistic/sales_detail_daily.go
+++ b/controller/statistic/sales_detail_daily.go
@@ -1,8 +1,10 @@
 package statistic
 
 import (
+	"jdy/enums"
 	"jdy/logic/statistic"
 	"jdy/types"
+	"time"
 
 	"github.com/gin-gonic/gin"
 )
@@ -20,12 +22,29 @@ func (con StatisticController) SalesDetailDaily(ctx *gin.Context) {
 		return
 	}
 
+	// 校验参数
+	if err := req.Validate(); err != nil {
+		con.Exception(ctx, err.Error())
+		return
+	}
+
 	// 获取当前登录用户
 	if staff, err := con.GetStaff(ctx); err != nil {
 		con.Exception(ctx, "无法获取")
 		return
 	} else {
 		logic.Staff = staff
+	}
+
+	// 如果是区域经理以下的身份
+	if logic.Staff.Identity < enums.IdentityAreaManager {
+		now := time.Now()
+		// 开始时间不能小于 2 个月前那一天的 0 点
+		start_limit := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, now.Location()).AddDate(0, -2, 0)
+		if req.StartTime.Before(start_limit) {
+			con.Exception(ctx, "开始时间不能小于 2 个月前")
+			return
+		}
 	}
 
 	res, err := logic.SalesDetailDaily(&req)

--- a/types/statistic_sales_detail_daily.go
+++ b/types/statistic_sales_detail_daily.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"errors"
 	"time"
 
 	"github.com/shopspring/decimal"
@@ -12,6 +13,15 @@ type StatisticSalesDetailDailyReq struct {
 
 	StartTime *time.Time `json:"start_time" binding:"required"` // 开始时间
 	EndTime   *time.Time `json:"end_time" binding:"required"`   // 结束时间
+}
+
+func (req *StatisticSalesDetailDailyReq) Validate() error {
+	// 开始时间不能大于结束时间
+	if req.StartTime.After(*req.EndTime) {
+		return errors.New("开始时间不能大于结束时间")
+	}
+
+	return nil
 }
 
 type StatisticSalesDetailDailyResp struct {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新功能
  - 新增参数校验：开始时间不得大于结束时间，失败返回“开始时间不能大于结束时间”。
  - 新增时间范围限制：非区域经理及以下，开始时间不得早于当月首日往前两个月，超限返回“开始时间不能小于 2 个月前”。
  - 查询流程保持不变，错误提示更清晰。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->