### PR TITLE
refactor: 新增门店别名;新增多总部;调整调拨单创建流程;

### DIFF
--- a/controller/store/store.go
+++ b/controller/store/store.go
@@ -34,6 +34,13 @@ func (con StoreController) List(ctx *gin.Context) {
 		return
 	}
 
+	if staff, err := con.GetStaff(ctx); err != nil {
+		con.ExceptionWithAuth(ctx, err)
+		return
+	} else {
+		logic.Staff = staff
+	}
+
 	// 查询门店列表
 	list, err := logic.List(ctx, &req)
 	if err != nil {
@@ -53,17 +60,17 @@ func (con StoreController) My(ctx *gin.Context) {
 		}
 	)
 
+	// 校验参数
+	if err := ctx.ShouldBind(&req); err != nil {
+		con.Exception(ctx, errors.ErrInvalidParam.Error())
+		return
+	}
+
 	if staff, err := con.GetStaff(ctx); err != nil {
 		con.ExceptionWithAuth(ctx, err)
 		return
 	} else {
 		logic.Staff = staff
-	}
-
-	// 校验参数
-	if err := ctx.ShouldBind(&req); err != nil {
-		con.Exception(ctx, errors.ErrInvalidParam.Error())
-		return
 	}
 
 	// 查询门店列表
@@ -92,6 +99,13 @@ func (con StoreController) Info(ctx *gin.Context) {
 	if err := ctx.ShouldBind(&req); err != nil {
 		con.Exception(ctx, errors.ErrInvalidParam.Error())
 		return
+	}
+
+	if staff, err := con.GetStaff(ctx); err != nil {
+		con.ExceptionWithAuth(ctx, err)
+		return
+	} else {
+		logic.Staff = staff
 	}
 
 	// 查询门店详情

--- a/controller/store/store.go
+++ b/controller/store/store.go
@@ -51,6 +51,36 @@ func (con StoreController) List(ctx *gin.Context) {
 	con.Success(ctx, "ok", list)
 }
 
+// 门店别名列表
+func (con StoreController) Alias(ctx *gin.Context) {
+	var (
+		req   types.StoreAliasReq
+		logic = store.StoreLogic{}
+	)
+
+	// 校验参数
+	if err := ctx.ShouldBind(&req); err != nil {
+		con.Exception(ctx, errors.ErrInvalidParam.Error())
+		return
+	}
+
+	if staff, err := con.GetStaff(ctx); err != nil {
+		con.ExceptionWithAuth(ctx, err)
+		return
+	} else {
+		logic.Staff = staff
+	}
+
+	// 查询门店别名列表
+	list, err := logic.Alias(ctx, &req)
+	if err != nil {
+		con.Exception(ctx, err.Error())
+		return
+	}
+
+	con.Success(ctx, "ok", list)
+}
+
 // 我的门店列表
 func (con StoreController) My(ctx *gin.Context) {
 	var (

--- a/logic/callback/change_contact_party.go
+++ b/logic/callback/change_contact_party.go
@@ -106,6 +106,7 @@ func (h *PartyCreateHandle) isStore(l *EventChangeContactEvent) error {
 		// 创建部门
 		store := model.Store{
 			IdWx:  fmt.Sprint(h.Party.ID),
+			Alias: h.Party.NameEN,
 			Name:  h.Party.Name,
 			Order: h.Party.Order,
 		}

--- a/logic/callback/change_contact_party.go
+++ b/logic/callback/change_contact_party.go
@@ -47,10 +47,12 @@ func (l *EventChangeContactEvent) CreateParty() error {
 	}
 
 	switch {
-	case strings.HasSuffix(party.Department.Name, "店"):
+	case strings.HasSuffix(party.Department.Name, model.StorePrefix):
 		return create_handle.isStore(l)
-	case strings.HasSuffix(party.Department.Name, "区域"):
+	case strings.HasSuffix(party.Department.Name, model.RegionPrefix):
 		return create_handle.isRegion(l)
+	case strings.HasSuffix(party.Department.Name, model.HeaderquartersPrefix):
+		return create_handle.isStore(l)
 	default:
 		return nil
 	}
@@ -72,16 +74,21 @@ func (l *EventChangeContactEvent) DeleteParty() error {
 		if err := tx.Where(&model.Store{
 			IdWx: msg.PartyDelete.ID,
 		}).Delete(&model.Store{}).Error; err != nil {
-			return err
+			if err != gorm.ErrRecordNotFound {
+				return err
+			}
 		}
 		if err := tx.Where(&model.Region{
 			IdWx: msg.PartyDelete.ID,
 		}).Delete(&model.Region{}).Error; err != nil {
-			return err
+			if err != gorm.ErrRecordNotFound {
+				return err
+			}
 		}
 
 		return nil
 	}); err != nil {
+		fmt.Printf("删除门店失败：%s\n", err.Error())
 		return err
 	}
 	return nil
@@ -135,7 +142,7 @@ func (h *PartyCreateHandle) isStore(l *EventChangeContactEvent) error {
 				return err
 			}
 			// 判断父级部门是否为区域
-			if strings.HasSuffix(parent.Department.Name, "区域") {
+			if strings.HasSuffix(parent.Department.Name, model.RegionPrefix) {
 				// 获取父级部门ID
 				var region model.Region
 				if err := tx.Where(&model.Region{
@@ -188,6 +195,7 @@ func (h *PartyCreateHandle) isRegion(l *EventChangeContactEvent) error {
 		region := model.Region{
 			IdWx:  fmt.Sprint(h.Party.ID),
 			Name:  h.Party.Name,
+			Alias: h.Party.NameEN,
 			Order: h.Party.Order,
 		}
 

--- a/logic/callback/change_contact_party.go
+++ b/logic/callback/change_contact_party.go
@@ -47,9 +47,9 @@ func (l *EventChangeContactEvent) CreateParty() error {
 	}
 
 	switch {
-	case strings.Contains(party.Department.Name, "店"):
+	case strings.HasSuffix(party.Department.Name, "店"):
 		return create_handle.isStore(l)
-	case strings.Contains(party.Department.Name, "区域"):
+	case strings.HasSuffix(party.Department.Name, "区域"):
 		return create_handle.isRegion(l)
 	default:
 		return nil
@@ -134,7 +134,7 @@ func (h *PartyCreateHandle) isStore(l *EventChangeContactEvent) error {
 				return err
 			}
 			// 判断父级部门是否为区域
-			if strings.Contains(parent.Department.Name, "区域") {
+			if strings.HasSuffix(parent.Department.Name, "区域") {
 				// 获取父级部门ID
 				var region model.Region
 				if err := tx.Where(&model.Region{

--- a/logic/product/accessorie_allocate.go
+++ b/logic/product/accessorie_allocate.go
@@ -38,11 +38,7 @@ func (l *ProductAccessorieAllocateLogic) Create(req *types.ProductAccessorieAllo
 			data.ToStoreId = req.ToStoreId
 		}
 		if req.Method == enums.ProductAccessorieAllocateMethodOut {
-			store, err := model.Store{}.Headquarters()
-			if err != nil {
-				return err
-			}
-			data.ToStoreId = store.Id
+			data.ToStoreId = req.ToHeadquartersId
 		}
 		if req.Method == enums.ProductAccessorieAllocateMethodRegion {
 			data.ToRegionId = req.ToRegionId
@@ -68,7 +64,7 @@ func (l *ProductAccessorieAllocateLogic) List(req *types.ProductAccessorieAlloca
 	)
 
 	db := model.DB.Model(&allocate)
-	db = allocate.WhereCondition(db, &req.Where)
+	db = allocate.WhereCondition(db, &req.Where, l.Staff)
 
 	// 获取总数
 	if err := db.Count(&res.Total).Error; err != nil {
@@ -96,7 +92,7 @@ func (l *ProductAccessorieAllocateLogic) Details(req *types.ProductAccessorieAll
 	)
 
 	db := model.DB.Model(&allocates)
-	db = model.ProductAccessorieAllocate{}.WhereCondition(db, &req.Where)
+	db = model.ProductAccessorieAllocate{}.WhereCondition(db, &req.Where, l.Staff)
 
 	// 获取列表
 	db = db.Order("created_at desc")

--- a/logic/product/allocate.go
+++ b/logic/product/allocate.go
@@ -43,11 +43,7 @@ func (l *ProductAllocateLogic) Create(req *types.ProductAllocateCreateReq) *erro
 			data.ToStoreId = req.ToStoreId
 		}
 		if req.Method == enums.ProductAllocateMethodOut {
-			store, err := model.Store{}.Headquarters()
-			if err != nil {
-				return err
-			}
-			data.ToStoreId = store.Id
+			data.ToStoreId = req.ToHeadquartersId
 		}
 
 		// 创建调拨单

--- a/logic/region/operation.go
+++ b/logic/region/operation.go
@@ -12,7 +12,8 @@ import (
 
 func (l *RegionLogic) Create(ctx *gin.Context, req *types.RegionCreateReq) error {
 	region := &model.Region{
-		Name: req.Name,
+		Name:  req.Name,
+		Alias: req.Alias,
 	}
 
 	if err := model.DB.Transaction(func(tx *gorm.DB) error {

--- a/logic/region/staff.go
+++ b/logic/region/staff.go
@@ -2,6 +2,7 @@ package region
 
 import (
 	"errors"
+	"jdy/enums"
 	"jdy/model"
 	"jdy/types"
 
@@ -17,8 +18,7 @@ type RegionStaffLogic struct {
 func (l *RegionStaffLogic) List(req *types.RegionStaffListReq) (*[]model.Staff, error) {
 	// 查询区域
 	var (
-		region   model.Region
-		inRegion = false
+		region model.Region
 	)
 
 	db := model.DB.Model(&model.Region{})
@@ -27,15 +27,10 @@ func (l *RegionStaffLogic) List(req *types.RegionStaffListReq) (*[]model.Staff, 
 		return nil, errors.New("区域不存在")
 	}
 
-	for _, staff := range region.Staffs {
-		if staff.Id == l.Staff.Id {
-			inRegion = true
-			break
+	if l.Staff.Identity < enums.IdentityAdmin {
+		if inRegion := region.InRegion(l.Staff.Id); !inRegion {
+			return nil, errors.New("无权查看该门店员工列表")
 		}
-	}
-
-	if !inRegion {
-		return nil, errors.New("未入职该区域，无法查看员工列表")
 	}
 
 	return &region.Staffs, nil

--- a/logic/store/operation.go
+++ b/logic/store/operation.go
@@ -12,14 +12,9 @@ import (
 
 func (l *StoreLogic) Create(ctx *gin.Context, req *types.StoreCreateReq) error {
 	store := &model.Store{
-		Name:     req.Name,
-		Address:  req.Address,
-		Contact:  req.Contact,
-		Logo:     req.Logo,
-		Order:    req.Order,
-		Province: req.Province,
-		City:     req.City,
-		District: req.District,
+		Name:  req.Name,
+		Alias: req.Alias,
+		Order: req.Order,
 	}
 
 	if err := model.DB.Transaction(func(tx *gorm.DB) error {

--- a/logic/store/store.go
+++ b/logic/store/store.go
@@ -37,6 +37,30 @@ func (l *StoreLogic) List(ctx *gin.Context, req *types.StoreListReq) (*types.Pag
 	return &res, nil
 }
 
+// 门店别名列表
+func (l *StoreLogic) Alias(ctx *gin.Context, req *types.StoreAliasReq) ([]model.Store, error) {
+	var (
+		store model.Store
+
+		res []model.Store
+	)
+
+	db := model.DB.Model(&store)
+
+	if req.IsHeadquarters {
+		db = db.Where("name like ?", "%"+model.HeaderquartersPrefix+"%")
+	} else {
+		db = db.Where("`alias` <> '' OR `alias` IS NOT NULL")
+		db = db.Omit("name")
+	}
+
+	if err := db.Find(&res).Error; err != nil {
+		return nil, errors.New("获取门店列表失败")
+	}
+
+	return res, nil
+}
+
 // 门店列表
 func (l *StoreLogic) My(req *types.StoreListMyReq) (*[]model.Store, error) {
 

--- a/logic/store/store.go
+++ b/logic/store/store.go
@@ -29,7 +29,7 @@ func (l *StoreLogic) List(ctx *gin.Context, req *types.StoreListReq) (*types.Pag
 	}
 
 	db = model.PageCondition(db, &req.PageReq)
-
+	db = store.Preloads(db)
 	if err := db.Find(&res.List).Error; err != nil {
 		return nil, errors.New("获取门店列表失败")
 	}

--- a/logic/sync/wxwork.go
+++ b/logic/sync/wxwork.go
@@ -58,7 +58,7 @@ func (l *WxWorkLogic) Contacts() error {
 			}
 
 			switch {
-			case strings.Contains(department.Department.Name, model.StorePrefix): // 如果是门店
+			case strings.HasSuffix(department.Department.Name, model.StorePrefix): // 如果是门店
 				store := model.Store{
 					IdWx:  fmt.Sprintf("%d", department.Department.ID),
 					Name:  department.Department.Name,
@@ -67,7 +67,7 @@ func (l *WxWorkLogic) Contacts() error {
 				if err := logic.getStore(store); err != nil {
 					return err
 				}
-			case strings.Contains(department.Department.Name, model.RegionPrefix): // 如果是区域
+			case strings.HasSuffix(department.Department.Name, model.RegionPrefix): // 如果是区域
 				region := model.Region{
 					IdWx:  fmt.Sprintf("%d", department.Department.ID),
 					Name:  department.Department.Name,
@@ -76,7 +76,7 @@ func (l *WxWorkLogic) Contacts() error {
 				if err := logic.getRegion(region); err != nil {
 					return err
 				}
-			case strings.Contains(department.Department.Name, model.HeaderquartersPrefix): // 如果是总部
+			case strings.HasSuffix(department.Department.Name, model.HeaderquartersPrefix): // 如果是总部
 				store := model.Store{
 					IdWx:  fmt.Sprintf("%d", department.Department.ID),
 					Name:  department.Department.Name,
@@ -176,7 +176,7 @@ func (l *WxWorkLogic) syncRegionStore() error {
 
 		var ids []string
 		for _, dept := range list.Departments {
-			if strings.Contains(dept.Name, "店") {
+			if strings.HasSuffix(dept.Name, "店") {
 				ids = append(ids, fmt.Sprintf("%d", dept.ID))
 			}
 		}
@@ -287,13 +287,13 @@ func (s *SyncWxWorkContacts) appendSuperior(name string, ids []string) error {
 	// 设置员工为门店/区域负责人
 	if strings.Contains(strings.Join(ids, " "), s.staff.Username) {
 		switch {
-		case strings.Contains(name, "店"): // 如果是门店
+		case strings.HasSuffix(name, "店"): // 如果是门店
 			if err := s.db.Model(&s.store).Association("Superiors").Append(&s.staff); err != nil {
 				log.Printf("关联负责人与门店失败: %+v", err)
 				return errors.New("关联负责人与门店失败")
 			}
 			s.staff.Identity = enums.IdentityShopkeeper
-		case strings.Contains(name, "区域"): // 如果是区域
+		case strings.HasSuffix(name, "区域"): // 如果是区域
 			if err := s.db.Model(&s.region).Association("Superiors").Append(&s.staff); err != nil {
 				log.Printf("关联负责人与区域失败: %+v", err)
 				return errors.New("关联负责人与区域失败")

--- a/logic/sync/wxwork.go
+++ b/logic/sync/wxwork.go
@@ -251,6 +251,7 @@ func (s *SyncWxWorkContacts) getRegion(where model.Region) error {
 		}
 		if err := s.db.Create(&region).Error; err != nil {
 			log.Printf("创建区域失败: %+v", err)
+			return errors.New("创建区域失败")
 		}
 	} else {
 		if err := s.db.Model(&model.Region{}).Where("id = ?", region.Id).Updates(where).Error; err != nil {

--- a/logic/sync/wxwork.go
+++ b/logic/sync/wxwork.go
@@ -58,7 +58,7 @@ func (l *WxWorkLogic) Contacts() error {
 			}
 
 			switch {
-			case strings.Contains(department.Department.Name, "店"): // 如果是门店
+			case strings.Contains(department.Department.Name, model.StorePrefix): // 如果是门店
 				store := model.Store{
 					IdWx:  fmt.Sprintf("%d", department.Department.ID),
 					Name:  department.Department.Name,
@@ -67,7 +67,7 @@ func (l *WxWorkLogic) Contacts() error {
 				if err := logic.getStore(store); err != nil {
 					return err
 				}
-			case strings.Contains(department.Department.Name, "区域"): // 如果是区域
+			case strings.Contains(department.Department.Name, model.RegionPrefix): // 如果是区域
 				region := model.Region{
 					IdWx:  fmt.Sprintf("%d", department.Department.ID),
 					Name:  department.Department.Name,
@@ -76,7 +76,7 @@ func (l *WxWorkLogic) Contacts() error {
 				if err := logic.getRegion(region); err != nil {
 					return err
 				}
-			case department.Department.Name == model.HeaderquartersName: // 如果是总部
+			case strings.Contains(department.Department.Name, model.HeaderquartersPrefix): // 如果是总部
 				store := model.Store{
 					IdWx:  fmt.Sprintf("%d", department.Department.ID),
 					Name:  department.Department.Name,

--- a/logic/sync/wxwork.go
+++ b/logic/sync/wxwork.go
@@ -179,7 +179,7 @@ func (l *WxWorkLogic) syncRegionStore() error {
 
 		var ids []string
 		for _, dept := range list.Departments {
-			if strings.HasSuffix(dept.Name, "店") {
+			if strings.HasSuffix(dept.Name, model.StorePrefix) {
 				ids = append(ids, fmt.Sprintf("%d", dept.ID))
 			}
 		}
@@ -261,7 +261,7 @@ func (s *SyncWxWorkContacts) getStaff(where model.Staff) error {
 
 // 关联门店
 func (s *SyncWxWorkContacts) appendStore() error {
-	// 关联员工与门店/区域
+	// 关联员工与门店
 	if s.store.IdWx != "" {
 		if err := s.db.Model(&s.staff).Association("Stores").Append(&s.store); err != nil {
 			log.Printf("关联员工与门店失败: %+v", err)
@@ -275,7 +275,7 @@ func (s *SyncWxWorkContacts) appendStore() error {
 
 // 关联区域
 func (s *SyncWxWorkContacts) appendRegion() error {
-	// 关联员工与门店/区域
+	// 关联员工与区域
 	if s.region.IdWx != "" {
 		if err := s.db.Model(&s.staff).Association("Regions").Append(&s.region); err != nil {
 			log.Printf("关联员工与区域失败: %+v", err)
@@ -292,13 +292,13 @@ func (s *SyncWxWorkContacts) appendSuperior(name string, ids []string) error {
 	// 设置员工为门店/区域负责人
 	if strings.Contains(strings.Join(ids, " "), s.staff.Username) {
 		switch {
-		case strings.HasSuffix(name, "店"): // 如果是门店
+		case strings.HasSuffix(name, model.StorePrefix): // 如果是门店
 			if err := s.db.Model(&s.store).Association("Superiors").Append(&s.staff); err != nil {
 				log.Printf("关联负责人与门店失败: %+v", err)
 				return errors.New("关联负责人与门店失败")
 			}
 			s.staff.Identity = enums.IdentityShopkeeper
-		case strings.HasSuffix(name, "区域"): // 如果是区域
+		case strings.HasSuffix(name, model.RegionPrefix): // 如果是区域
 			if err := s.db.Model(&s.region).Association("Superiors").Append(&s.staff); err != nil {
 				log.Printf("关联负责人与区域失败: %+v", err)
 				return errors.New("关联负责人与区域失败")

--- a/logic/sync/wxwork.go
+++ b/logic/sync/wxwork.go
@@ -62,6 +62,7 @@ func (l *WxWorkLogic) Contacts() error {
 				store := model.Store{
 					IdWx:  fmt.Sprintf("%d", department.Department.ID),
 					Name:  department.Department.Name,
+					Alias: department.Department.NameEN,
 					Order: department.Department.Order,
 				}
 				if err := logic.getStore(store); err != nil {
@@ -71,6 +72,7 @@ func (l *WxWorkLogic) Contacts() error {
 				region := model.Region{
 					IdWx:  fmt.Sprintf("%d", department.Department.ID),
 					Name:  department.Department.Name,
+					Alias: department.Department.NameEN,
 					Order: department.Department.Order,
 				}
 				if err := logic.getRegion(region); err != nil {
@@ -80,6 +82,7 @@ func (l *WxWorkLogic) Contacts() error {
 				store := model.Store{
 					IdWx:  fmt.Sprintf("%d", department.Department.ID),
 					Name:  department.Department.Name,
+					Alias: department.Department.NameEN,
 					Order: department.Department.Order,
 				}
 				if err := logic.getStore(store); err != nil {
@@ -203,6 +206,7 @@ func (s *SyncWxWorkContacts) getStore(where model.Store) error {
 	if err := s.db.Where("id_wx = ?", where.IdWx).Attrs(model.Store{
 		IdWx:  where.IdWx,
 		Name:  where.Name,
+		Alias: where.Alias,
 		Order: where.Order,
 	}).FirstOrCreate(&store).Error; err != nil {
 		log.Printf("获取门店失败: %+v", err)
@@ -221,6 +225,7 @@ func (s *SyncWxWorkContacts) getRegion(where model.Region) error {
 	if err := s.db.Where("id_wx = ?", where.IdWx).Attrs(model.Region{
 		IdWx:  where.IdWx,
 		Name:  where.Name,
+		Alias: where.Alias,
 		Order: where.Order,
 	}).FirstOrCreate(&region).Error; err != nil {
 		log.Printf("获取区域失败: %+v", err)

--- a/model/product_accessorie_allocate.go
+++ b/model/product_accessorie_allocate.go
@@ -42,7 +42,7 @@ type ProductAccessorieAllocate struct {
 	Receiver   *Staff `json:"receiver" gorm:"foreignKey:ReceiverId;references:Id;comment:接收人;"` // 接收人
 }
 
-func (ProductAccessorieAllocate) WhereCondition(db *gorm.DB, query *types.ProductAccessorieAllocateWhere) *gorm.DB {
+func (ProductAccessorieAllocate) WhereCondition(db *gorm.DB, query *types.ProductAccessorieAllocateWhere, staff *Staff) *gorm.DB {
 	if query.Id != "" {
 		db = db.Where("id = ?", query.Id)
 	}

--- a/model/product_allocate.go
+++ b/model/product_allocate.go
@@ -74,12 +74,7 @@ func (ProductAllocate) WhereCondition(db *gorm.DB, query *types.ProductAllocateW
 		db = db.Where("created_at <= ?", query.EndTime)
 	}
 	if query.StoreId != "" {
-		if store := staff.GetStore(query.StoreId); store.IsHeadquarters() {
-			// 总部
-			db = db.Where("from_store_id IN (?) AND to_store_id = ?", staff.StoreIds, query.StoreId)
-		} else {
-			db = db.Where("from_store_id = ? OR to_store_id = ?", query.StoreId, query.StoreId)
-		}
+		db = db.Where("from_store_id = ? OR to_store_id = ?", query.StoreId, query.StoreId)
 	}
 	if query.InitiatorId != "" {
 		db = db.Where("initiator_id = ?", query.InitiatorId)

--- a/model/product_allocate.go
+++ b/model/product_allocate.go
@@ -74,7 +74,9 @@ func (ProductAllocate) WhereCondition(db *gorm.DB, query *types.ProductAllocateW
 		db = db.Where("created_at <= ?", query.EndTime)
 	}
 	if query.StoreId != "" {
-		db = db.Where("from_store_id = ? OR to_store_id = ?", query.StoreId, query.StoreId)
+		db = db.Where(
+			db.Where("from_store_id = ?", query.StoreId).Or("to_store_id = ?", query.StoreId),
+		)
 	}
 	if query.InitiatorId != "" {
 		db = db.Where("initiator_id = ?", query.InitiatorId)

--- a/model/region.go
+++ b/model/region.go
@@ -36,6 +36,21 @@ func (Region) Preloads(db *gorm.DB) *gorm.DB {
 	return db
 }
 
+func (region *Region) InRegion(staff_id string) bool {
+	for _, staff := range region.Staffs {
+		if staff.Id == staff_id {
+			return true
+		}
+	}
+	for _, staff := range region.Superiors {
+		if staff.Id == staff_id {
+			return true
+		}
+	}
+
+	return false
+}
+
 func (Region) Default(identity enums.Identity) *Region {
 	if identity < enums.IdentityAdmin {
 		return nil

--- a/model/region.go
+++ b/model/region.go
@@ -11,14 +11,14 @@ import (
 type Region struct {
 	SoftDelete
 
-	IdWx  string `json:"id_wx" gorm:"size:255;comment:微信ID"` // 微信ID
-	Name  string `json:"name" gorm:"size:255;comment:名称"`    // 名称
-	Alias string `json:"alias" gorm:"size:255;comment:别名"`   // 别名
-	Order int    `json:"order" gorm:"comment:排序"`            // 排序
+	IdWx  string `json:"id_wx" gorm:"index;size:255;comment:微信ID"` // 微信ID
+	Name  string `json:"name" gorm:"index;size:255;comment:名称"`    // 名称
+	Alias string `json:"alias" gorm:"index;size:255;comment:别名"`   // 别名
+	Order int    `json:"order" gorm:"comment:排序"`                  // 排序
 
-	Stores    []Store `json:"stores" gorm:"many2many:region_stores;"`       // 门店
-	Staffs    []Staff `json:"staffs" gorm:"many2many:region_staffs;"`       // 员工
-	Superiors []Staff `json:"superiors" gorm:"many2many:region_superiors;"` // 负责人
+	Stores    []Store `json:"stores" gorm:"foreignKey:RegionId;references:Id;comment:门店"` // 门店
+	Staffs    []Staff `json:"staffs" gorm:"many2many:region_staffs;"`                     // 员工
+	Superiors []Staff `json:"superiors" gorm:"many2many:region_superiors;"`               // 负责人
 }
 
 func (Region) WhereCondition(db *gorm.DB, query *types.RegionWhere) *gorm.DB {

--- a/model/region.go
+++ b/model/region.go
@@ -13,6 +13,7 @@ type Region struct {
 
 	IdWx  string `json:"id_wx" gorm:"size:255;comment:微信ID"` // 微信ID
 	Name  string `json:"name" gorm:"size:255;comment:名称"`    // 名称
+	Alias string `json:"alias" gorm:"size:255;comment:别名"`   // 别名
 	Order int    `json:"order" gorm:"comment:排序"`            // 排序
 
 	Stores    []Store `json:"stores" gorm:"many2many:region_stores;"`       // 门店

--- a/model/region.go
+++ b/model/region.go
@@ -25,6 +25,9 @@ func (Region) WhereCondition(db *gorm.DB, query *types.RegionWhere) *gorm.DB {
 	if query.Name != "" {
 		db = db.Where("name LIKE ?", fmt.Sprintf("%%%s%%", query.Name))
 	}
+	if query.Alias != "" {
+		db = db.Where("alias = ?", query.Alias)
+	}
 
 	return db
 }

--- a/model/staff.go
+++ b/model/staff.go
@@ -36,6 +36,7 @@ type Staff struct {
 	StoreIds        []string `json:"store_ids" gorm:"-"`                                  // 店铺ID
 	Stores          []Store  `json:"stores" gorm:"many2many:store_staffs;"`               // 店铺
 	StoreSuperiors  []Store  `json:"store_superiors" gorm:"many2many:store_superiors;"`   // 负责的店铺
+	RegionIds       []string `json:"region_ids" gorm:"-"`                                 // 区域ID
 	Regions         []Region `json:"regions" gorm:"many2many:region_staffs;"`             // 区域
 	RegionSuperiors []Region `json:"region_superiors" gorm:"many2many:region_superiors;"` // 负责的区域
 }
@@ -92,11 +93,13 @@ func (Staff) Get(Id, Username *string) (*Staff, error) {
 		staff.StoreIds = append(staff.StoreIds, store.Id)
 	}
 	for _, region := range staff.Regions {
+		staff.RegionIds = append(staff.RegionIds, region.Id)
 		for _, store := range region.Stores {
 			staff.StoreIds = append(staff.StoreIds, store.Id)
 		}
 	}
 	for _, region := range staff.RegionSuperiors {
+		staff.RegionIds = append(staff.RegionIds, region.Id)
 		for _, store := range region.Stores {
 			staff.StoreIds = append(staff.StoreIds, store.Id)
 		}
@@ -140,6 +143,25 @@ func (staff *Staff) GetStore(store_id string) *Store {
 			if staff.RegionSuperiors[ri].Stores[si].Id == store_id {
 				return &staff.RegionSuperiors[ri].Stores[si]
 			}
+		}
+	}
+
+	return nil
+}
+
+func (staff *Staff) GetRegion(region_id string) *Region {
+	if staff == nil || region_id == "" {
+		return nil
+	}
+
+	for ri := range staff.Regions {
+		if staff.Regions[ri].Id == region_id {
+			return &staff.Regions[ri]
+		}
+	}
+	for ri := range staff.RegionSuperiors {
+		if staff.RegionSuperiors[ri].Id == region_id {
+			return &staff.RegionSuperiors[ri]
 		}
 	}
 

--- a/model/store.go
+++ b/model/store.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"jdy/enums"
 	"jdy/types"
+	"strings"
 
 	"gorm.io/gorm"
 )
@@ -70,23 +71,16 @@ func (Store) Default(identity enums.Identity) *Store {
 	return def
 }
 
-const HeaderquartersName = "总部"
-
-func (Store) Headquarters() (*Store, error) {
-	var store Store
-	if err := DB.Where(&Store{
-		Name: HeaderquartersName,
-	}).First(&store).Error; err != nil {
-		return nil, err
-	}
-	return &store, nil
-}
+const StorePrefix = "店"
+const RegionPrefix = "区域"
+const HeaderquartersPrefix = "总部"
 
 func (store *Store) IsHeadquarters() bool {
 	if store == nil {
 		return false
 	}
-	return store.Name == HeaderquartersName
+
+	return strings.Contains(store.Name, HeaderquartersPrefix)
 }
 
 func init() {

--- a/model/store.go
+++ b/model/store.go
@@ -39,6 +39,7 @@ func (Store) WhereCondition(db *gorm.DB, query *types.StoreWhere) *gorm.DB {
 }
 
 func (Store) Preloads(db *gorm.DB) *gorm.DB {
+	db = db.Preload("Region")
 	db = db.Preload("Staffs")
 	db = db.Preload("Superiors")
 

--- a/model/store.go
+++ b/model/store.go
@@ -80,7 +80,7 @@ func (store *Store) IsHeadquarters() bool {
 		return false
 	}
 
-	return strings.Contains(store.Name, HeaderquartersPrefix)
+	return strings.HasSuffix(store.Name, HeaderquartersPrefix)
 }
 
 func (store *Store) InStore(staff_id string) bool {

--- a/model/store.go
+++ b/model/store.go
@@ -51,7 +51,8 @@ func (Store) Default(identity enums.Identity) *Store {
 		return nil
 	}
 	def := &Store{
-		Name: "全部",
+		Name:  "全部",
+		Alias: "全部",
 	}
 
 	return def

--- a/model/store.go
+++ b/model/store.go
@@ -12,17 +12,13 @@ import (
 type Store struct {
 	SoftDelete
 
-	IdWx  string `json:"id_wx" gorm:"size:255;comment:微信ID"` // 微信ID
-	Name  string `json:"name" gorm:"size:255;comment:名称"`    // 名称
-	Alias string `json:"alias" gorm:"size:255;comment:别名"`   // 别名
-	Order int    `json:"order" gorm:"comment:排序"`            // 排序
+	IdWx  string `json:"id_wx" gorm:"index;size:255;comment:微信ID"` // 微信ID
+	Name  string `json:"name" gorm:"index;size:255;comment:名称"`    // 名称
+	Alias string `json:"alias" gorm:"index;size:255;comment:别名"`   // 别名
+	Order int    `json:"order" gorm:"index;comment:排序"`            // 排序
 
-	Logo     string `json:"logo" gorm:"size:255;comment:logo"`    // logo
-	Contact  string `json:"contact" gorm:"size:255;comment:联系方式"` // 联系方式
-	Province string `json:"province" gorm:"size:255;comment:省份"`  // 省份
-	City     string `json:"city" gorm:"size:255;comment:城市"`      // 城市
-	District string `json:"district" gorm:"size:255;comment:区域"`  // 区域
-	Address  string `json:"address" gorm:"size:500;comment:地址"`   // 地址
+	RegionId string `json:"region_id" gorm:"index;size:255;comment:区域ID"`               // 区域ID
+	Region   Region `json:"region" gorm:"foreignKey:RegionId;references:Id;comment:区域"` // 区域
 
 	Staffs    []Staff `json:"staffs" gorm:"many2many:store_staffs;"`       // 员工
 	Superiors []Staff `json:"superiors" gorm:"many2many:store_superiors;"` // 负责人
@@ -32,23 +28,11 @@ func (Store) WhereCondition(db *gorm.DB, query *types.StoreWhere) *gorm.DB {
 	if query.Name != "" {
 		db = db.Where("name LIKE ?", fmt.Sprintf("%%%s%%", query.Name))
 	}
-	if query.Address != "" {
-		db = db.Where("address LIKE ?", fmt.Sprintf("%%%s%%", query.Address))
-	}
-	if query.Contact != "" {
-		db = db.Where("contact LIKE ?", fmt.Sprintf("%%%s%%", query.Contact))
-	}
-	if query.Field.Province != nil {
-		db = db.Where("province LIKE ?", fmt.Sprintf("%%%s%%", *query.Field.Province))
-	}
-	if query.Field.City != nil {
-		db = db.Where("city LIKE ?", fmt.Sprintf("%%%s%%", *query.Field.City))
-	}
-	if query.Field.District != nil {
-		db = db.Where("district LIKE ?", fmt.Sprintf("%%%s%%", *query.Field.District))
+	if query.Alias != "" {
+		db = db.Where("alias = ?", query.Alias)
 	}
 	if query.RegionId != "" {
-		db = db.Where("id IN (SELECT store_id FROM region_stores WHERE region_id = ?)", query.RegionId)
+		db = db.Where("region_id = ?", query.RegionId)
 	}
 
 	return db

--- a/model/store.go
+++ b/model/store.go
@@ -14,6 +14,7 @@ type Store struct {
 
 	IdWx  string `json:"id_wx" gorm:"size:255;comment:微信ID"` // 微信ID
 	Name  string `json:"name" gorm:"size:255;comment:名称"`    // 名称
+	Alias string `json:"alias" gorm:"size:255;comment:别名"`   // 别名
 	Order int    `json:"order" gorm:"comment:排序"`            // 排序
 
 	Logo     string `json:"logo" gorm:"size:255;comment:logo"`    // logo

--- a/model/store.go
+++ b/model/store.go
@@ -83,6 +83,21 @@ func (store *Store) IsHeadquarters() bool {
 	return strings.Contains(store.Name, HeaderquartersPrefix)
 }
 
+func (store *Store) InStore(staff_id string) bool {
+	for _, staff := range store.Staffs {
+		if staff.Id == staff_id {
+			return true
+		}
+	}
+	for _, staff := range store.Superiors {
+		if staff.Id == staff_id {
+			return true
+		}
+	}
+
+	return false
+}
+
 func init() {
 	// 注册模型
 	RegisterModels(

--- a/router/api.go
+++ b/router/api.go
@@ -203,6 +203,7 @@ func Api(g *gin.Engine) {
 					root.PUT("/update", store.StoreController{}.Update)    // 门店更新
 					root.DELETE("/delete", store.StoreController{}.Delete) // 门店删除
 					root.POST("/list", store.StoreController{}.List)       // 门店列表
+					root.POST("/alias", store.StoreController{}.Alias)     // 门店别名
 					root.POST("/my", store.StoreController{}.My)           // 我的门店
 					root.POST("/info", store.StoreController{}.Info)       // 门店详情
 				}

--- a/service/crons/report_statistic.go
+++ b/service/crons/report_statistic.go
@@ -39,7 +39,7 @@ func SendReportStatistic() {
 	// 获取所有门店
 	var allStore []model.Store
 	sdb := model.DB.Model(&model.Store{})
-	sdb = sdb.Where("name <> ?", model.HeaderquartersName)
+	sdb = sdb.Where("name NOT LIKE (?)", "%"+model.HeaderquartersPrefix+"%")
 	sdb = sdb.Order("name desc")
 	if err := sdb.Find(&allStore).Error; err != nil {
 		log.Printf("SendReportStatistic error: %v", err.Error())

--- a/types/product_accessorie_allocate.go
+++ b/types/product_accessorie_allocate.go
@@ -19,8 +19,8 @@ func (req *ProductAccessorieAllocateCreateReq) Validate() error {
 	if req.Method == enums.ProductAccessorieAllocateMethodStore && req.ToStoreId == "" {
 		return errors.New("调拨门店不能为空")
 	}
-	if req.Method == enums.ProductAccessorieAllocateMethodOut && req.ToHeadquartersId == "" && req.Remark == "" {
-		return errors.New("调拨备注不能为空")
+	if req.Method == enums.ProductAccessorieAllocateMethodOut && req.ToHeadquartersId == "" {
+		return errors.New("调拨总部不能为空")
 	}
 	if req.Method == enums.ProductAccessorieAllocateMethodRegion && req.ToRegionId == "" {
 		return errors.New("调拨门店不能为空")

--- a/types/product_accessorie_allocate.go
+++ b/types/product_accessorie_allocate.go
@@ -7,18 +7,19 @@ import (
 )
 
 type ProductAccessorieAllocateCreateReq struct {
-	Method      enums.ProductAccessorieAllocateMethod `json:"method" binding:"required"`        // 调拨类型
-	FromStoreId string                                `json:"from_store_id" binding:"required"` // 调出门店
-	ToStoreId   string                                `json:"to_store_id"`                      // 调入门店
-	ToRegionId  string                                `json:"to_region_id"`                     // 调入区域
-	Remark      string                                `json:"remark"`                           // 备注
+	Method           enums.ProductAccessorieAllocateMethod `json:"method" binding:"required"`        // 调拨类型
+	FromStoreId      string                                `json:"from_store_id" binding:"required"` // 调出门店
+	ToStoreId        string                                `json:"to_store_id"`                      // 调入门店
+	ToRegionId       string                                `json:"to_region_id"`                     // 调入区域
+	ToHeadquartersId string                                `json:"to_headquarters_id"`               // 调入总部
+	Remark           string                                `json:"remark"`                           // 备注
 }
 
 func (req *ProductAccessorieAllocateCreateReq) Validate() error {
 	if req.Method == enums.ProductAccessorieAllocateMethodStore && req.ToStoreId == "" {
 		return errors.New("调拨门店不能为空")
 	}
-	if req.Method == enums.ProductAccessorieAllocateMethodOut && req.Remark == "" {
+	if req.Method == enums.ProductAccessorieAllocateMethodOut && req.ToHeadquartersId == "" && req.Remark == "" {
 		return errors.New("调拨备注不能为空")
 	}
 	if req.Method == enums.ProductAccessorieAllocateMethodRegion && req.ToRegionId == "" {
@@ -29,12 +30,13 @@ func (req *ProductAccessorieAllocateCreateReq) Validate() error {
 }
 
 type ProductAccessorieAllocateWhere struct {
-	Id          string                                `json:"id" label:"调拨单号" input:"text" type:"string" find:"true" create:"false" info:"true" sort:"1" required:"false"`                                                                              // 调拨ID
-	Status      enums.ProductAllocateStatus           `json:"status" label:"调拨状态" input:"select" type:"number" find:"true" create:"false" info:"true" sort:"2" required:"true" preset:"typeMap"`                                                        // 调拨状态
-	Method      enums.ProductAccessorieAllocateMethod `json:"method" label:"调拨类型" input:"select" type:"number" find:"true" create:"true" info:"true" sort:"3" required:"true" preset:"typeMap"`                                                         // 调拨类型
-	FromStoreId string                                `json:"from_store_id" label:"调出门店" input:"search" type:"string" find:"true" create:"false" info:"true" sort:"4" required:"false"`                                                                 // 调出门店
-	ToStoreId   string                                `json:"to_store_id" label:"调入门店" input:"search" type:"string" find:"true" create:"true" info:"true" sort:"5" required:"true"  condition:"[{\"key\":\"method\",\"operator\":\"=\",\"value\":1}]"`  // 调入门店
-	ToRegionId  string                                `json:"to_region_id" label:"调入区域" input:"search" type:"string" find:"true" create:"true" info:"true" sort:"6" required:"true"  condition:"[{\"key\":\"method\",\"operator\":\"=\",\"value\":3}]"` // 调入区域
+	Id               string                                `json:"id" label:"调拨单号" input:"text" type:"string" find:"true" create:"false" info:"true" sort:"1" required:"false"`                                                                                      // 调拨ID
+	Status           enums.ProductAllocateStatus           `json:"status" label:"调拨状态" input:"select" type:"number" find:"true" create:"false" info:"true" sort:"2" required:"true" preset:"typeMap"`                                                                // 调拨状态
+	Method           enums.ProductAccessorieAllocateMethod `json:"method" label:"调拨类型" input:"select" type:"number" find:"true" create:"true" info:"true" sort:"3" required:"true" preset:"typeMap"`                                                                 // 调拨类型
+	FromStoreId      string                                `json:"from_store_id" label:"调出门店" input:"search" type:"string" find:"true" create:"false" info:"true" sort:"4" required:"false"`                                                                         // 调出门店
+	ToStoreId        string                                `json:"to_store_id" label:"调入门店" input:"search" type:"string" find:"true" create:"true" info:"true" sort:"5" required:"true"  condition:"[{\"key\":\"method\",\"operator\":\"=\",\"value\":1}]"`          // 调入门店
+	ToRegionId       string                                `json:"to_region_id" label:"调入区域" input:"search" type:"string" find:"true" create:"true" info:"true" sort:"6" required:"true"  condition:"[{\"key\":\"method\",\"operator\":\"=\",\"value\":3}]"`         // 调入区域
+	ToHeadquartersId string                                `json:"to_headquarters_id" label:"调入总部" input:"search" type:"string" find:"false" create:"true" info:"false" sort:"7" required:"true"  condition:"[{\"key\":\"method\",\"operator\":\"=\",\"value\":2}]"` // 调入总部
 
 	ProductCount int64 `json:"product_count" label:"种类数" info:"true" sort:"7" required:"false"`
 	ProductTotal int64 `json:"product_total" label:"总件数" info:"true" sort:"8" required:"false"`

--- a/types/product_allocate.go
+++ b/types/product_allocate.go
@@ -7,12 +7,13 @@ import (
 )
 
 type ProductAllocateCreateReq struct {
-	Method      enums.ProductAllocateMethod `json:"method" binding:"required"`        // 调拨类型
-	Type        enums.ProductType           `json:"type" binding:"required"`          // 仓库类型
-	Reason      enums.ProductAllocateReason `json:"reason" binding:"required"`        // 调拨原因
-	Remark      string                      `json:"remark"`                           // 备注
-	FromStoreId string                      `json:"from_store_id" binding:"required"` // 调出门店
-	ToStoreId   string                      `json:"to_store_id"`                      // 调入门店
+	Method           enums.ProductAllocateMethod `json:"method" binding:"required"`        // 调拨类型
+	Type             enums.ProductType           `json:"type" binding:"required"`          // 仓库类型
+	Reason           enums.ProductAllocateReason `json:"reason" binding:"required"`        // 调拨原因
+	Remark           string                      `json:"remark"`                           // 备注
+	FromStoreId      string                      `json:"from_store_id" binding:"required"` // 调出门店
+	ToStoreId        string                      `json:"to_store_id"`                      // 调入门店
+	ToHeadquartersId string                      `json:"to_headquarters_id"`               // 调入总部
 
 	EnterId string `json:"enter_id"` // 入库单号
 }
@@ -26,13 +27,14 @@ func (req *ProductAllocateCreateReq) Validate() error {
 }
 
 type ProductAllocateWhere struct {
-	Id          string                      `json:"id" label:"调拨单号" input:"text" type:"string" find:"true" create:"true" sort:"1" required:"false"`                         // 调拨单号
-	Method      enums.ProductAllocateMethod `json:"method" label:"调拨类型" input:"select" type:"number" find:"true" create:"true" sort:"2" required:"true" preset:"typeMap"`   // 调拨类型
-	Type        enums.ProductType           `json:"type" label:"仓库类型" input:"select" type:"number" find:"true" create:"true" sort:"3" required:"true" preset:"typeMap"`     // 仓库类型
-	Reason      enums.ProductAllocateReason `json:"reason" label:"调拨原因" input:"select" type:"number" find:"true" create:"true" sort:"4" required:"true" preset:"typeMap"`   // 调拨原因
-	FromStoreId string                      `json:"from_store_id" label:"调出门店" input:"search" type:"string" find:"true" sort:"5" required:"false"`                          // 调出门店
-	ToStoreId   string                      `json:"to_store_id" label:"调入门店" input:"search" type:"string" find:"true" create:"true"  sort:"6" required:"false"`             // 调入门店
-	Status      enums.ProductAllocateStatus `json:"status" label:"调拨状态" input:"select" type:"number" find:"true" create:"false" sort:"7" required:"false" preset:"typeMap"` // 调拨状态
+	Id               string                      `json:"id" label:"调拨单号" input:"text" type:"string" find:"true" create:"true" sort:"1" required:"false"`                         // 调拨单号
+	Method           enums.ProductAllocateMethod `json:"method" label:"调拨类型" input:"select" type:"number" find:"true" create:"true" sort:"2" required:"true" preset:"typeMap"`   // 调拨类型
+	Type             enums.ProductType           `json:"type" label:"仓库类型" input:"select" type:"number" find:"true" create:"true" sort:"3" required:"true" preset:"typeMap"`     // 仓库类型
+	Reason           enums.ProductAllocateReason `json:"reason" label:"调拨原因" input:"select" type:"number" find:"true" create:"true" sort:"4" required:"true" preset:"typeMap"`   // 调拨原因
+	FromStoreId      string                      `json:"from_store_id" label:"调出门店" input:"search" type:"string" find:"true" sort:"5" required:"false"`                          // 调出门店
+	ToStoreId        string                      `json:"to_store_id" label:"调入门店" input:"search" type:"string" find:"true" create:"true"  sort:"6" required:"false"`             // 调入门店
+	ToHeadquartersId string                      `json:"to_headquarters_id" label:"调入总部" input:"search" type:"string" find:"false" create:"true" sort:"6" required:"false"`      // 调入总部
+	Status           enums.ProductAllocateStatus `json:"status" label:"调拨状态" input:"select" type:"number" find:"true" create:"false" sort:"7" required:"false" preset:"typeMap"` // 调拨状态
 
 	StartTime *time.Time `json:"start_time" label:"开始时间" input:"date" type:"date" find:"true" sort:"8" required:"false"` // 开始时间
 	EndTime   *time.Time `json:"end_time" label:"结束时间" input:"date" type:"date" find:"true" sort:"9" required:"false"`   // 结束时间

--- a/types/product_allocate.go
+++ b/types/product_allocate.go
@@ -22,6 +22,9 @@ func (req *ProductAllocateCreateReq) Validate() error {
 	if req.Method == enums.ProductAllocateMethodStore && req.ToStoreId == "" {
 		return errors.New("调拨门店不能为空")
 	}
+	if req.Method == enums.ProductAllocateMethodOut && req.ToHeadquartersId == "" {
+		return errors.New("调拨总部不能为空")
+	}
 
 	return nil
 }

--- a/types/region.go
+++ b/types/region.go
@@ -1,7 +1,8 @@
 package types
 
 type RegionCreateReq struct {
-	Name string `json:"name" binding:"required"` // 区域名称
+	Name  string `json:"name" binding:"required"`  // 名称
+	Alias string `json:"alias" binding:"required"` // 别名
 }
 
 type RegionUpdateReq struct {
@@ -28,7 +29,8 @@ type RegionListMyReq struct {
 }
 
 type RegionWhere struct {
-	Name string `json:"name" label:"区域名称" find:"true" sort:"1" type:"string" input:"text"`
+	Name  string `json:"name" label:"区域名称" find:"true" sort:"1" type:"string" input:"text"`  // 名称
+	Alias string `json:"alias" label:"区域别名" find:"true" sort:"1" type:"string" input:"text"` // 别名
 }
 
 type RegionStoreListReq struct {

--- a/types/region.go
+++ b/types/region.go
@@ -8,7 +8,8 @@ type RegionCreateReq struct {
 type RegionUpdateReq struct {
 	Id string `json:"id" binding:"required"`
 
-	RegionCreateReq
+	Name  string `json:"name"`  // 名称
+	Alias string `json:"alias"` // 别名
 }
 
 type RegionDeleteReq struct {

--- a/types/store.go
+++ b/types/store.go
@@ -36,7 +36,8 @@ type StoreListMyReq struct {
 }
 
 type StoreWhere struct {
-	Name     string `json:"name" label:"门店名称" find:"true" sort:"1" type:"string" input:"text"`
+	Name     string `json:"name" label:"名称" find:"true" sort:"1" type:"string" input:"text"`
+	Alias    string `json:"alias" label:"别名" find:"true" sort:"1" type:"string" input:"text"`
 	Field    Field  `json:"field" label:"区域" find:"false" sort:"2" type:"object" input:"region"`
 	Address  string `json:"address" label:"门店地址" find:"true" sort:"5" type:"string" input:"text"`
 	Contact  string `json:"contact" label:"联系方式" find:"true" sort:"6" type:"string" input:"text"`

--- a/types/store.go
+++ b/types/store.go
@@ -10,7 +10,9 @@ type StoreCreateReq struct {
 type StoreUpdateReq struct {
 	Id string `json:"id" binding:"required"`
 
-	StoreCreateReq
+	Order int    `json:"order" binding:"min=0"` // 排序
+	Name  string `json:"name"`                  // 名称
+	Alias string `json:"alias"`                 // 别名
 }
 
 type StoreDeleteReq struct {
@@ -24,6 +26,10 @@ type StoreInfoReq struct {
 type StoreListReq struct {
 	PageReq
 	Where StoreWhere `json:"where"`
+}
+
+type StoreAliasReq struct {
+	IsHeadquarters bool `json:"is_headquarters"` // 是否是总部
 }
 
 type StoreListMyReq struct {

--- a/types/store.go
+++ b/types/store.go
@@ -3,13 +3,8 @@ package types
 type StoreCreateReq struct {
 	Order int `json:"order" binding:"min=0"` // 排序
 
-	Name     string `json:"name" binding:"required"`     // 门店名称
-	Province string `json:"province" binding:"required"` // 省份
-	City     string `json:"city" binding:"required"`     // 城市
-	District string `json:"district" binding:"required"` // 区域
-	Address  string `json:"address" binding:"required"`  // 门店地址
-	Contact  string `json:"contact" binding:"required"`  // 联系方式
-	Logo     string `json:"logo"`                        // 门店logo
+	Name  string `json:"name" binding:"required"`  // 名称
+	Alias string `json:"alias" binding:"required"` // 别名
 }
 
 type StoreUpdateReq struct {
@@ -36,19 +31,9 @@ type StoreListMyReq struct {
 }
 
 type StoreWhere struct {
-	Name     string `json:"name" label:"名称" find:"true" sort:"1" type:"string" input:"text"`
-	Alias    string `json:"alias" label:"别名" find:"true" sort:"1" type:"string" input:"text"`
-	Field    Field  `json:"field" label:"区域" find:"false" sort:"2" type:"object" input:"region"`
-	Address  string `json:"address" label:"门店地址" find:"true" sort:"5" type:"string" input:"text"`
-	Contact  string `json:"contact" label:"联系方式" find:"true" sort:"6" type:"string" input:"text"`
-	Logo     string `json:"logo" label:"门店logo" find:"false" sort:"7" type:"string" input:"upload"`
-	RegionId string `json:"region_id" label:"区域" find:"false" sort:"3" type:"string" input:"text"`
-}
-
-type Field struct {
-	Province *string `json:"province"`
-	City     *string `json:"city"`
-	District *string `json:"district"`
+	Name     string `json:"name" label:"名称" find:"true" sort:"1" type:"string" input:"text"`      // 名称
+	Alias    string `json:"alias" label:"别名" find:"true" sort:"1" type:"string" input:"text"`     // 别名
+	RegionId string `json:"region_id" label:"区域" find:"true" sort:"3" type:"string" input:"text"` // 区域
 }
 
 type StoreStaffListReq struct {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新功能
  - 支持“调入总部”调拨：创建与筛选新增调入总部字段，外发调拨需填写调入总部。
  - 新增门店别名查询接口：提供门店别名列表（含总部标识）供前端使用。

- 改进
  - 门店/区域新增 Alias 字段，用于显示、同步与搜索。
  - 员工新增 RegionIds 并支持按区域查找与成员校验。
  - 列表/详情查询引入基于当前员工的权限校验（非管理员需为门店/区域成员）。
  - 总部/门店/区域识别改为名称后缀匹配；调拨筛选简化为以门店参与方为准。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->