### PR TITLE
refactor(message): 修改报告统计消息格式和发送方式

### DIFF
--- a/message/report_statistic.go
+++ b/message/report_statistic.go
@@ -32,37 +32,34 @@ type ReportStatisticMessage struct {
 func (M *BaseMessage) SendReportStatisticMessage(req *ReportStatisticMessage) {
 
 	content := []string{
-		fmt.Sprintf("###### %s(%s)", req.StoreName, req.StatisticalTime.Format("01-02")),
-		"",
-		fmt.Sprintf("销售业绩：**%s**", req.TodayFinished.StringFixed(2)),
-		fmt.Sprintf("旧料抵扣：**%s**", req.TodayOld.StringFixed(2)),
-		fmt.Sprintf("配件收款：**%s**", req.TodayAcciessorie.StringFixed(2)),
-		"",
+		fmt.Sprintf("%s(%s)", req.StoreName, req.StatisticalTime.Format("01-02")),
+		fmt.Sprintf("销售业绩：%s", req.TodayFinished.StringFixed(2)),
+		fmt.Sprintf("旧料抵扣：%s", req.TodayOld.StringFixed(2)),
+		fmt.Sprintf("配件收款：%s", req.TodayAcciessorie.StringFixed(2)),
 	}
 	for class, total := range req.TodayFinisheds {
 		content = append(content,
-			fmt.Sprintf("> %s ：**%s**", class, total.StringFixed(2)),
+			fmt.Sprintf("%s ：%s", class, total.StringFixed(2)),
 		)
 	}
 	content = append(content, []string{
-		"",
-		fmt.Sprintf("月度销售：**%s**", req.MonthFinished.StringFixed(2)),
-		fmt.Sprintf("月度抵扣：**%s**", req.MonthOld.StringFixed(2)),
-		fmt.Sprintf("月度配件：**%s**", req.MonthAcciessorie.StringFixed(2)),
+		fmt.Sprintf("月度销售：%s", req.MonthFinished.StringFixed(2)),
+		fmt.Sprintf("月度抵扣：%s", req.MonthOld.StringFixed(2)),
+		fmt.Sprintf("月度配件：%s", req.MonthAcciessorie.StringFixed(2)),
 	}...)
 
-	messages := &request.RequestMessageSendMarkdown{
+	messages := &request.RequestMessageSendText{
 		RequestMessageSend: request.RequestMessageSend{
 			ToUser:  strings.Join(req.ToUser, "|"),
-			MsgType: "markdown",
+			MsgType: "text",
 			AgentID: M.Config.Jdy.Id,
 		},
-		Markdown: &request.RequestMarkdown{
+		Text: &request.RequestText{
 			Content: strings.Join(content, "\n"),
 		},
 	}
 
-	if res, err := M.WXWork.Message.SendMarkdown(M.Ctx, messages); err != nil || (res != nil && res.ErrCode != 0) {
+	if res, err := M.WXWork.Message.SendText(M.Ctx, messages); err != nil || (res != nil && res.ErrCode != 0) {
 		log.Println("发送消息失败:", err)
 		log.Printf("res: %+v\n", res)
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 样式
  - 消息由 Markdown 改为纯文本显示，移除标题、加粗与引用列表，统一为普通行展示。
  - 门店与日期、今日业绩、旧料抵扣、配件收款等信息按行呈现，无多余空行。
  - 月度汇总行改为普通文本，提升跨终端显示一致性与可读性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->