### PR TITLE
fix(report): 销售日报信息排除退货

### DIFF
--- a/service/crons/report_statistic.go
+++ b/service/crons/report_statistic.go
@@ -85,7 +85,7 @@ func SendReportStatistic() {
 				switch product.Type {
 				case enums.ProductTypeFinished:
 					{
-						price := req.TodayFinished.Add(product.Finished.Price)
+						price := product.Finished.Price
 
 						for _, refund := range today_refunds {
 							if refund.Type != enums.ProductTypeFinished {
@@ -111,7 +111,7 @@ func SendReportStatistic() {
 					}
 				case enums.ProductTypeOld:
 					{
-						price := req.TodayOld.Add(product.Old.RecyclePrice)
+						price := product.Old.RecyclePrice
 
 						for _, refund := range today_refunds {
 							if refund.Type != enums.ProductTypeOld {
@@ -131,7 +131,7 @@ func SendReportStatistic() {
 					}
 				case enums.ProductTypeAccessorie:
 					{
-						price := req.TodayAcciessorie.Add(product.Accessorie.Price)
+						price := product.Accessorie.Price
 
 						for _, refund := range today_refunds {
 							if refund.Type != enums.ProductTypeAccessorie {
@@ -158,7 +158,7 @@ func SendReportStatistic() {
 				switch product.Type {
 				case enums.ProductTypeFinished:
 					{
-						price := req.MonthFinished.Add(product.Finished.Price)
+						price := product.Finished.Price
 
 						for _, refund := range month_refunds {
 							if refund.Type != enums.ProductTypeFinished {
@@ -178,7 +178,7 @@ func SendReportStatistic() {
 					}
 				case enums.ProductTypeOld:
 					{
-						price := req.MonthOld.Add(product.Old.RecyclePrice)
+						price := product.Old.RecyclePrice
 
 						for _, refund := range month_refunds {
 							if refund.Type != enums.ProductTypeOld {
@@ -198,7 +198,7 @@ func SendReportStatistic() {
 					}
 				case enums.ProductTypeAccessorie:
 					{
-						price := req.MonthAcciessorie.Add(product.Accessorie.Price)
+						price := product.Accessorie.Price
 
 						for _, refund := range month_refunds {
 							if refund.Type != enums.ProductTypeAccessorie {
@@ -263,7 +263,7 @@ func SendReportStatistic() {
 			if !ok {
 				continue
 			}
-			req.ToUser = []string{staff.Username}
+			req.ToUser = []string{"ZhangMingShuai"}
 			msg.SendReportStatisticMessage(&req)
 		}
 	}

--- a/service/crons/report_statistic.go
+++ b/service/crons/report_statistic.go
@@ -263,7 +263,7 @@ func SendReportStatistic() {
 			if !ok {
 				continue
 			}
-			req.ToUser = []string{"ZhangMingShuai"}
+			req.ToUser = []string{staff.Username}
 			msg.SendReportStatisticMessage(&req)
 		}
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新功能
  - 报表统计改为基于销售额而非订单数，新增今日/本月退款统计。
  - 按成品/旧料/配件分别展示今日与本月的销售净额（自动扣减对应退款），支持门店维度的日/月汇总与对比。

- 修复
  - 修正统计口径，避免因退款导致的重复或虚高；金额为零的项目在当日统计中不再计入，提高准确性与可读性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->