### PR TITLE
feat(statistic): 个人业绩增加详细信息展示

### DIFF
--- a/model/order_sales.go
+++ b/model/order_sales.go
@@ -97,8 +97,10 @@ func (OrderSales) Preloads(db *gorm.DB) *gorm.DB {
 	db = db.Preload("Member")
 	db = db.Preload("Store")
 	db = db.Preload("Cashier")
-	db = db.Preload("Clerks", func(tx *gorm.DB) *gorm.DB {
-		return tx.Preload("Salesman")
+	db = db.Preload("Clerks", func(tx1 *gorm.DB) *gorm.DB {
+		return tx1.Preload("Salesman", func(tx2 *gorm.DB) *gorm.DB {
+			return tx2.Unscoped()
+		})
 	})
 	db = db.Preload("Products", func(tx *gorm.DB) *gorm.DB {
 		tx = tx.Preload("Finished", func(tx1 *gorm.DB) *gorm.DB {
@@ -177,8 +179,11 @@ func (OrderSalesProduct) WhereCondition(db *gorm.DB, req *types.OrderSalesDetail
 
 func (OrderSalesProduct) Preloads(db *gorm.DB) *gorm.DB {
 	db = db.Preload("Order", func(tx *gorm.DB) *gorm.DB {
-		tx = tx.Preload("Clerks.Salesman")
-
+		tx = tx.Preload("Clerks", func(tx1 *gorm.DB) *gorm.DB {
+			return tx1.Preload("Salesman", func(tx2 *gorm.DB) *gorm.DB {
+				return tx2.Unscoped()
+			})
+		})
 		return tx
 	})
 	db = db.Preload("Store")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新功能
  - 报表新增“业绩”指标，并与各类销售额联动更新。
  - 销售明细新增字段：旧料抵扣、旧料抵扣件数、旧料回收、旧料回收件数；完善配件销售额与配件件数展示。
- 修复
  - 退款现在同时影响业绩及对应分类销售额（成品、旧料交换/回收、配件），统计更准确。
  - 关联列表中可正确显示业务员信息（含被软删除的历史记录），避免缺失。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->